### PR TITLE
Add support for aliases to modules, including scoped modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,16 +50,24 @@ export default function({ types: t }) {
                     if(aliasConf.hasOwnProperty(aliasFrom)) {
 
                         let aliasTo = aliasConf[aliasFrom];
-
-                        // If the filepath is not absolute, make it absolute
-                        if(!isAbsolute(aliasTo)) {
-                            aliasTo = join(process.cwd(), aliasTo);
-                        }
-
                         let regex = new RegExp(`^${aliasFrom}(\/|$)`);
 
                         // If the regex matches, replace by the right config
                         if(regex.test(filePath)) {
+
+                            // notModuleRegExp from https://github.com/webpack/enhanced-resolve/blob/master/lib/Resolver.js
+                            const notModuleRegExp = /^\.$|^\.[\\\/]|^\.\.$|^\.\.[\/\\]|^\/|^[A-Z]:[\\\/]/i;
+                            let isModule = !notModuleRegExp.test(aliasTo);
+
+                            if(isModule) {
+                                path.node.arguments = [StringLiteral(aliasTo)];
+                                return;
+                            }
+
+                            // If the filepath is not absolute, make it absolute
+                            if(!isAbsolute(aliasTo)) {
+                                aliasTo = join(process.cwd(), aliasTo);
+                            }
                             let relativeFilePath = relative(dirname(filename), aliasTo).replace(/\\/g, '/');
 
                             // In case the file path is the root of the alias, need to put a dot to avoid having an absolute path

--- a/test/fixtures/module.expected.js
+++ b/test/fixtures/module.expected.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('module-name');
+require('@scoped/module-name');
+
+// Rest of the file

--- a/test/fixtures/module.js
+++ b/test/fixtures/module.js
@@ -1,0 +1,4 @@
+require('my-alternate-module-name');
+require('my-scoped-module-name');
+
+// Rest of the file

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -46,6 +46,11 @@ test('requiring files from the root', t => {
     t.is(actual, expected);
 });
 
+test('requiring module from by alternate name', t => {
+    const actual = transformFile('fixtures/module.js', {config: './runtime.webpack.config.js'}).code;
+    const expected = read('fixtures/module.expected.js');
+    t.is(actual, expected);
+});
 
 test('using the import syntax', t => {
     const actual = transformFile('fixtures/import.js', {config: './runtime.webpack.config.js'}).code;

--- a/test/runtime.webpack.config.js
+++ b/test/runtime.webpack.config.js
@@ -6,7 +6,9 @@ module.exports = {
         alias: {
             'my-absolute-test-lib': path.join(__dirname, 'assets/le-test-lib'),
             'my-relative-test-lib': './assets/le-test-lib/',
-            'my-root-folder-lib': './fixtures/'
+            'my-root-folder-lib': './fixtures/',
+            'my-alternate-module-name': 'module-name',
+            'my-scoped-module-name': '@scoped/module-name'
         }
     }
 };


### PR DESCRIPTION
This fixes a bug which causes this plugin to not load all the webpack aliases the same way webpack does, e.g. for aliasing scoped modules.