### PR TITLE
feat(option): Added a noOutputExtension option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ function getConfigPath(configPaths, findConfig) {
 export default function({ types: t }) {
     return {
         visitor: {
-            CallExpression(path, { file: { opts: { filename } }, opts: { config: configPath, findConfig: findConfig = false } = {} }) {
+            CallExpression(path, {file: { opts: { filename } }, opts: { config: configPath, findConfig: findConfig = false, noOutputExtension = false } = {} }) {
                 const configPaths = configPath ? [configPath, ...DEFAULT_CONFIG_NAMES] : DEFAULT_CONFIG_NAMES;
 
                 // Get webpack config
@@ -182,7 +182,7 @@ export default function({ types: t }) {
                             }
 
                             // In case the extension option is passed
-                            if(extensionsConf) {
+                            if(extensionsConf && !noOutputExtension) {
                                 // Get an absolute path to the file
                                 const absoluteRequire = join(aliasTo, basename(filePath));
 

--- a/test/fixtures/no-extension/expected.js
+++ b/test/fixtures/no-extension/expected.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('../required/myfile');
+require('../required/doesntExist');
+
+// Rest of the file

--- a/test/fixtures/no-extension/source.js
+++ b/test/fixtures/no-extension/source.js
@@ -1,0 +1,4 @@
+require('my-absolute-test-lib/myfile');
+require('my-absolute-test-lib/doesntExist');
+
+// Rest of the file

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -106,3 +106,8 @@ test('works with webpack configs that export an array, instead of a single objec
     t.is(actual, expected);
 });
 
+test('doesnt output extensions when noOutputExtension is set to true', t => {
+    const actual = transformFixture('no-extension/source.js', {config: './extensions.config.js', noOutputExtension: true});
+    const expected = readFixture('no-extension/expected.js');
+    t.is(actual, expected);
+});


### PR DESCRIPTION
Even when extensions is specified in the webpack config, don't add file extensions in the output require.

Fixes #25