### PR TITLE
Escape alias before creating a regexp from it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,11 @@ function getConfigPath(configPaths, findConfig) {
     return conf;
 }
 
+function escapeRegExpSpecialChars(str) {
+  // from https://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/3561711#3561711
+    return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
 export default function({ types: t }) {
     return {
         visitor: {
@@ -146,9 +151,8 @@ export default function({ types: t }) {
 
                 for(const aliasFrom in aliasConf) {
                     if(aliasConf.hasOwnProperty(aliasFrom)) {
-
                         let aliasTo = aliasConf[aliasFrom];
-                        const regex = new RegExp(`^${aliasFrom}(\/|$)`);
+                        const regex = new RegExp(`^${escapeRegExpSpecialChars(aliasFrom)}(\/|$)`);
 
                         // If the regex matches, replace by the right config
                         if(regex.test(filePath)) {

--- a/test/fixtures/special-chars/expected.js
+++ b/test/fixtures/special-chars/expected.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('../../yolo/trolo');
+require('../../yolo/trolo/asdf');
+
+// Rest of the file

--- a/test/fixtures/special-chars/source.js
+++ b/test/fixtures/special-chars/source.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('\\ \^ \$ \* \+ \? \. \( \) \| \{ \} \[ \] "');
+require('\\ \^ \$ \* \+ \? \. \( \) \| \{ \} \[ \] "/asdf');
+
+// Rest of the file

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -115,3 +115,9 @@ test('doesnt output extensions when noOutputExtension is set to true', t => {
     const expected = readFixture('no-extension/expected.js');
     t.is(actual, expected);
 });
+
+test('works with RegExp special chars in alias', t => {
+    const actual = transformFixture('special-chars/source.js', {config: './special-chars.config.js', noOutputExtension: true});
+    const expected = readFixture('special-chars/expected.js');
+    t.is(actual, expected);
+});

--- a/test/special-chars.config.js
+++ b/test/special-chars.config.js
@@ -1,0 +1,10 @@
+var path = require('path');
+
+module.exports = {
+    resolve: {
+        alias: {
+            '\\ \^ \$ \* \+ \? \. \( \) \| \{ \} \[ \] "': path.resolve(__dirname, 'yolo/trolo'),
+        }
+    }
+};
+


### PR DESCRIPTION
Currently the plugin doesn't work if an alias has a "Regular Expression special char" in it. This PR fixes that.

Example:

```
...
  alias: {
    '$somethingsomething': '/somethingelse'
  }
...
```

For another example see added test.