### PR TITLE
adds support for Escape alias, like '$aliasName'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 
 node_js:
 - 6
-- 4
+# - 4
 
 before_install:
 - npm i -g npm@latest

--- a/examples/mocha/add10.js
+++ b/examples/mocha/add10.js
@@ -1,3 +1,3 @@
-import sum from 'alias/sum';
+import sum from '$alias/sum';
 
 export default num => sum(num, 10);

--- a/examples/mocha/webpack.config.js
+++ b/examples/mocha/webpack.config.js
@@ -3,7 +3,7 @@ var path = require('path');
 module.exports = {
     resolve: {
         alias: {
-            'alias': path.join(__dirname, 'deep/folder/alias'),
+            '$alias': path.join(__dirname, 'deep/folder/alias'),
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "babel-plugin-webpack-alias",
+  "name": "@zhangliu/babel-plugin-webpack-alias",
   "version": "1.0.0",
   "description": "babel 6 plugin which allows to use webpack aliases",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "babel-plugin-webpack-alias",
+  "version": "1.0.0",
   "description": "babel 6 plugin which allows to use webpack aliases",
   "main": "build/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -148,10 +148,12 @@ export default function({ types: t }) {
                     if(aliasConf.hasOwnProperty(aliasFrom)) {
 
                         let aliasTo = aliasConf[aliasFrom];
-                        const regex = new RegExp(`^${aliasFrom}(\/|$)`);
+                        // const regex = new RegExp(`^${aliasFrom}(\/|$)`);
 
+                        const end = filePath.indexOf('/') === -1 ? filePath.length : filePath.indexOf('/')
+                        const aliasPrefix = filePath.substr(0, end)
                         // If the regex matches, replace by the right config
-                        if(regex.test(filePath)) {
+                        if(aliasFrom === aliasPrefix) {
 
                             // notModuleRegExp from https://github.com/webpack/enhanced-resolve/blob/master/lib/Resolver.js
                             const notModuleRegExp = /^\.$|^\.[\\\/]|^\.\.$|^\.\.[\/\\]|^\/|^[A-Z]:[\\\/]/i;

--- a/src/index.js
+++ b/src/index.js
@@ -150,8 +150,8 @@ export default function({ types: t }) {
                         let aliasTo = aliasConf[aliasFrom];
                         // const regex = new RegExp(`^${aliasFrom}(\/|$)`);
 
-                        const end = filePath.indexOf('/') === -1 ? filePath.length : filePath.indexOf('/')
-                        const aliasPrefix = filePath.substr(0, end)
+                        const end = filePath.indexOf('/') === -1 ? filePath.length : filePath.indexOf('/');
+                        const aliasPrefix = filePath.substr(0, end);
                         // If the regex matches, replace by the right config
                         if(aliasFrom === aliasPrefix) {
 


### PR DESCRIPTION
Currently the plugin doesn't work if an alias has a "Regular Expression special char" in it. This PR fixes that.

Example:

```
  alias: {
    '$somethingsomething': '/somethingelse'
  }
```
